### PR TITLE
Update NugRunningOptions.lua

### DIFF
--- a/Options/NugRunningOptions.lua
+++ b/Options/NugRunningOptions.lua
@@ -189,7 +189,9 @@ function NugRunningGUI.CreateCommonForm(self)
                 return
             end
             if not GetSpellInfo(spellID) then
-                return -- spell doesn't exist
+                if GetItemInfo(spellID) == nil then    
+                    return -- spell doesn't exist
+                end
             end
 
             if not opts.name then


### PR DESCRIPTION
some times add and activete, but some item don't. i find some item don't have spell info. therefore, check item info and null to return.