### PR TITLE
Take back the totem timer with LibTotemInfo-1.0

### DIFF
--- a/.pkgmeta
+++ b/.pkgmeta
@@ -9,6 +9,7 @@ externals:
   Libs/AceGUI-3.0-SharedMediaWidgets: https://repos.wowace.com/wow/ace-gui-3-0-shared-media-widgets/trunk/AceGUI-3.0-SharedMediaWidgets
   Libs/AceConfig-3.0: https://repos.wowace.com/wow/ace3/trunk/AceConfig-3.0
   Libs/LibSharedMedia-3.0: https://repos.wowace.com/wow/libsharedmedia-3-0/trunk/LibSharedMedia-3.0
+  Libs/LibTotemInfo-1.0: https://github.com/SwimmingTiger/LibTotemInfo
 
 move-folders:
   NugRunning/Options/loader: NugRunningOptions

--- a/NugRunning.lua
+++ b/NugRunning.lua
@@ -423,7 +423,7 @@ function NugRunning.PLAYER_LOGIN(self,event,arg1)
     SLASH_NUGRUNNING2= "/nrun"
     SlashCmdList["NUGRUNNING"] = NugRunning.SlashCmd
 
-    -- if NRunDB.totems and NugRunning.InitTotems then NugRunning:InitTotems() end
+    if NRunDB.totems and NugRunning.InitTotems then NugRunning:InitTotems() end
     NugRunning.SetupSpecialTimers()
 
 

--- a/NugRunning.toc
+++ b/NugRunning.toc
@@ -12,6 +12,7 @@
 Libs\LibStub\LibStub.lua
 Libs\CallbackHandler-1.0\CallbackHandler-1.0.lua
 Libs\LibSharedMedia-3.0\lib.xml
+Libs\LibTotemInfo-1.0\embeds.xml
 
 helpers.lua
 classic.config.lua

--- a/Options/NugRunningOptions.lua
+++ b/Options/NugRunningOptions.lua
@@ -1831,6 +1831,14 @@ local function MakeGeneralOptions()
                         set = function(info, v) NugRunning.Commands.cooldowns() end,
                         order = 6,
                     },
+                    totems = {
+                        name = L"Totems",
+                        type = "toggle",
+                        desc = L"Display timers for totems (or other similar summons)",
+                        get = function(info) return NugRunning.db.totems end,
+                        set = function(info, v) NugRunning.db.totems = not NugRunning.db.totems end,
+                        order = 7,
+                    },
                     swapTargets = {
                         name = L"Fixed Target Group"..newFeatureIcon,
                         type = "toggle",

--- a/totems.lua
+++ b/totems.lua
@@ -1,6 +1,8 @@
 -- if select(2,UnitClass("player")) ~= "SHAMAN" then return end
 if not next(NugRunningConfig.totems) then return end
 
+local GetTotemInfo = LibStub("LibTotemInfo-1.0").GetTotemInfo
+
 NugRunning.InitTotems = function(self)
 
     local active = NugRunning.active


### PR DESCRIPTION
I noticed that because Blizzard removed `GetTotemInfo ()`, the totem timer has been removed from `NugRunning`.

However, I have created A compatible implementation of `GetTotemInfo ()`, which can be used as a library. So we can bring the totem timer back to NugRunning.